### PR TITLE
Hostname and secret as macros

### DIFF
--- a/Zabbix_Templates/TemplateAppBigBlueButtonServer.xml
+++ b/Zabbix_Templates/TemplateAppBigBlueButtonServer.xml
@@ -93,7 +93,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -161,7 +161,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -229,7 +229,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -297,7 +297,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -365,7 +365,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -433,7 +433,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -441,7 +441,7 @@ Tested on release 2.2</description>
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>bbb.miner[getMeetings]</key>
+                    <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     <delay>1m</delay>
                     <history>0</history>
                     <trends>0</trends>
@@ -500,7 +500,7 @@ Tested on release 2.2</description>
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>bbb.miner[getRecordings]</key>
+                    <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     <delay>10m</delay>
                     <history>0</history>
                     <trends>0</trends>
@@ -619,7 +619,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -687,7 +687,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -755,7 +755,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -823,7 +823,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -891,7 +891,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -959,7 +959,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -1027,7 +1027,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -1095,7 +1095,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -1163,7 +1163,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -1231,7 +1231,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getRecordings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getRecordings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -1299,7 +1299,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
                 <item>
@@ -1367,7 +1367,7 @@ Tested on release 2.2</description>
                     <verify_peer>0</verify_peer>
                     <verify_host>0</verify_host>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </item>
             </items>
@@ -1470,7 +1470,7 @@ Tested on release 2.2</description>
                                 </application_prototype>
                             </application_prototypes>
                             <master_item>
-                                <key>bbb.miner[getMeetings]</key>
+                                <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -1539,7 +1539,7 @@ Tested on release 2.2</description>
                                 </application_prototype>
                             </application_prototypes>
                             <master_item>
-                                <key>bbb.miner[getMeetings]</key>
+                                <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -1608,7 +1608,7 @@ Tested on release 2.2</description>
                                 </application_prototype>
                             </application_prototypes>
                             <master_item>
-                                <key>bbb.miner[getMeetings]</key>
+                                <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -1677,7 +1677,7 @@ Tested on release 2.2</description>
                                 </application_prototype>
                             </application_prototypes>
                             <master_item>
-                                <key>bbb.miner[getMeetings]</key>
+                                <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -1746,7 +1746,7 @@ Tested on release 2.2</description>
                                 </application_prototype>
                             </application_prototypes>
                             <master_item>
-                                <key>bbb.miner[getMeetings]</key>
+                                <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                             </master_item>
                         </item_prototype>
                     </item_prototypes>
@@ -1875,7 +1875,7 @@ return ret;</params>
                         </step>
                     </preprocessing>
                     <master_item>
-                        <key>bbb.miner[getMeetings]</key>
+                        <key>bbb.miner[{$BBB_HOSTNAME},{$BBB_SECRET},getMeetings]</key>
                     </master_item>
                 </discovery_rule>
             </discovery_rules>
@@ -1888,10 +1888,21 @@ return ret;</params>
                 <macro>
                     <macro>{$BBB_KEEP_MEETING_GENERATED_ITEMS}</macro>
                     <value>7d</value>
+					<description>All LLD-generated meetings's Applications will be stored for the time specified in this macro.</description>
                 </macro>
                 <macro>
                     <macro>{$BBB_KEEP_MEETING_TREND}</macro>
                     <value>365d</value>
+                </macro>
+                <macro>
+                    <macro>{$BBB_HOSTNAME}</macro>
+                    <value>bbb.example.com</value>
+					<description>BBB server hostname which used for the SSL-certificate. Copy to you host using 'inherited and host macros' after linking the template.</description>
+                </macro>
+                <macro>
+                    <macro>{$BBB_SECRET}</macro>
+                    <value>BigBlueButtonSecretStringThere</value>
+					<description>Your BBB server secret. You can get it from bbb-conf --secret command output. Copy to you host using 'inherited and host macros' after linking the template.</description>
                 </macro>
             </macros>
             <templates/>

--- a/Zabbix_Templates/TemplateAppBigBlueButtonServer.xml
+++ b/Zabbix_Templates/TemplateAppBigBlueButtonServer.xml
@@ -1401,7 +1401,7 @@ Tested on release 2.2</description>
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>{$KEEP_MEETING_GENERATED_ITEMS}</lifetime>
+                    <lifetime>{$BBB_KEEP_MEETING_GENERATED_ITEMS}</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
@@ -1411,8 +1411,8 @@ Tested on release 2.2</description>
                             <snmp_oid/>
                             <key>bbb.broadcastersCount[{#ID}]</key>
                             <delay>0</delay>
-                            <history>{$KEEP_MEETING_DATA}</history>
-                            <trends>{$KEEP_MEETING_TREND}</trends>
+                            <history>{$BBB_KEEP_MEETING_DATA}</history>
+                            <trends>{$BBB_KEEP_MEETING_TREND}</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
@@ -1480,8 +1480,8 @@ Tested on release 2.2</description>
                             <snmp_oid/>
                             <key>bbb.listenersCount[{#ID}]</key>
                             <delay>0</delay>
-                            <history>{$KEEP_MEETING_DATA}</history>
-                            <trends>{$KEEP_MEETING_TREND}</trends>
+                            <history>{$BBB_KEEP_MEETING_DATA}</history>
+                            <trends>{$BBB_KEEP_MEETING_TREND}</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
@@ -1549,8 +1549,8 @@ Tested on release 2.2</description>
                             <snmp_oid/>
                             <key>bbb.moderatorCount[{#ID}]</key>
                             <delay>0</delay>
-                            <history>{$KEEP_MEETING_DATA}</history>
-                            <trends>{$KEEP_MEETING_TREND}</trends>
+                            <history>{$BBB_KEEP_MEETING_DATA}</history>
+                            <trends>{$BBB_KEEP_MEETING_TREND}</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
@@ -1618,8 +1618,8 @@ Tested on release 2.2</description>
                             <snmp_oid/>
                             <key>bbb.participantsCount[{#ID}]</key>
                             <delay>0</delay>
-                            <history>{$KEEP_MEETING_DATA}</history>
-                            <trends>{$KEEP_MEETING_TREND}</trends>
+                            <history>{$BBB_KEEP_MEETING_DATA}</history>
+                            <trends>{$BBB_KEEP_MEETING_TREND}</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
@@ -1687,8 +1687,8 @@ Tested on release 2.2</description>
                             <snmp_oid/>
                             <key>bbb.voiceParticipantsCount[{#ID}]</key>
                             <delay>0</delay>
-                            <history>{$KEEP_MEETING_DATA}</history>
-                            <trends>{$KEEP_MEETING_TREND}</trends>
+                            <history>{$BBB_KEEP_MEETING_DATA}</history>
+                            <trends>{$BBB_KEEP_MEETING_TREND}</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>
@@ -1882,15 +1882,15 @@ return ret;</params>
             <httptests/>
             <macros>
                 <macro>
-                    <macro>{$KEEP_MEETING_DATA}</macro>
+                    <macro>{$BBB_KEEP_MEETING_DATA}</macro>
                     <value>90d</value>
                 </macro>
                 <macro>
-                    <macro>{$KEEP_MEETING_GENERATED_ITEMS}</macro>
+                    <macro>{$BBB_KEEP_MEETING_GENERATED_ITEMS}</macro>
                     <value>7d</value>
                 </macro>
                 <macro>
-                    <macro>{$KEEP_MEETING_TREND}</macro>
+                    <macro>{$BBB_KEEP_MEETING_TREND}</macro>
                     <value>365d</value>
                 </macro>
             </macros>

--- a/Zabbix_Templates/TemplateAppBigBlueButtonServer.xml
+++ b/Zabbix_Templates/TemplateAppBigBlueButtonServer.xml
@@ -1888,7 +1888,6 @@ return ret;</params>
                 <macro>
                     <macro>{$BBB_KEEP_MEETING_GENERATED_ITEMS}</macro>
                     <value>7d</value>
-					<description>All LLD-generated meetings's Applications will be stored for the time specified in this macro.</description>
                 </macro>
                 <macro>
                     <macro>{$BBB_KEEP_MEETING_TREND}</macro>
@@ -1897,12 +1896,10 @@ return ret;</params>
                 <macro>
                     <macro>{$BBB_HOSTNAME}</macro>
                     <value>bbb.example.com</value>
-					<description>BBB server hostname which used for the SSL-certificate. Copy to you host using 'inherited and host macros' after linking the template.</description>
                 </macro>
                 <macro>
                     <macro>{$BBB_SECRET}</macro>
                     <value>BigBlueButtonSecretStringThere</value>
-					<description>Your BBB server secret. You can get it from bbb-conf --secret command output. Copy to you host using 'inherited and host macros' after linking the template.</description>
                 </macro>
             </macros>
             <templates/>

--- a/zabbix_agentd.bbb.conf
+++ b/zabbix_agentd.bbb.conf
@@ -1,1 +1,1 @@
-UserParameter=bbb.miner[*],curl -s https://bbb.example.com/bigbluebutton/api/$1?checksum=`echo -n "$1BigBlueButtonSecretStringThere" | sha1sum | head -c 40` 2>&1
+UserParameter=bbb.miner[*],curl -s https://$1/bigbluebutton/api/$3?checksum=`echo -n "$3$2" | sha1sum | head -c 40` 2>&1


### PR DESCRIPTION
It's just a sugestion. I think it's easier to manage everything if both hostname and secrets are also set as parameters.
Editing the UserParameter can get messy and it's easier to not screw things up if you don't edit the bash command. 
Using it as a macro is also easier because you can set something like {$BBB_HOSTNAME} =  {$HOST.DNS} on the template and you wouldn't need to set each host individually

Edit: I actually just realized than I'm not sure if you can set a macro using another macro value on Zabbix, but I think my point is still valid. 